### PR TITLE
CMake: Added parson to r.info, r.profile, v.info

### DIFF
--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -284,7 +284,7 @@ if(NOT MSVC)
   build_program_in_subdir(r.in.xyz DEPENDS grass_gis grass_raster LIBM)
 endif()
 build_program_in_subdir(r.info TEST_SOURCES "test_r_info.py" DEPENDS grass_gis LIBM
-                        grass_raster)
+                        grass_raster grass_parson)
 
 build_program_in_subdir(r.kappa DEPENDS grass_gis grass_raster LIBM)
 
@@ -376,7 +376,7 @@ build_program_in_subdir(r.patch DEPENDS grass_gis grass_raster OPTIONAL_DEPENDS
 
 build_program_in_subdir(r.path DEPENDS grass_gis grass_raster grass_vector)
 
-build_program_in_subdir(r.profile DEPENDS grass_gis grass_raster LIBM)
+build_program_in_subdir(r.profile DEPENDS grass_gis grass_raster grass_parson LIBM)
 
 build_program_in_subdir(
   r.proj

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -274,7 +274,8 @@ build_program_in_subdir(
   grass_dbmidriver
   grass_dig2
   grass_gis
-  grass_vector)
+  grass_vector
+  grass_parson)
 
 build_program_in_subdir(
   v.in.ascii


### PR DESCRIPTION
This PR fixes error related to Parson dependency.
```
Creating /home/mahesh98/usr/local/src/grass/build_dir/output/lib64/grass85/docs/html/r.in.xyz.html
[ 51%] Built target r.in.xyz
[ 51%] Building C object raster/CMakeFiles/r.info.dir/r.info/main.c.o
[ 51%] Building C object raster/CMakeFiles/r.info.dir/r.info/reclas_txt.c.o
[ 51%] Linking C executable ../output/lib64/grass85/bin/r.info
/usr/bin/ld: CMakeFiles/r.info.dir/r.info/main.c.o: undefined reference to symbol 'json_object_set_string@@JSONC_0.14'
/usr/bin/ld: /usr/lib64/libjson-c.so.5: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
gmake[2]: *** [raster/CMakeFiles/r.info.dir/build.make:116: output/lib64/grass85/bin/r.info] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:10468: raster/CMakeFiles/r.info.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```