### PR TITLE
Added parson to r.univar, r3.univar, v.univar

### DIFF
--- a/raster/r.univar/CMakeLists.txt
+++ b/raster/r.univar/CMakeLists.txt
@@ -9,6 +9,7 @@ build_program(
   DEPENDS
   grass_gis
   grass_raster
+  grass_parson
   LIBM
   OPTIONAL_DEPENDS
   OPENMP)
@@ -22,6 +23,7 @@ build_program(
   grass_gis
   grass_raster
   grass_raster3d
+  grass_parson
   LIBM
   OPTIONAL_DEPENDS
   OPENMP)

--- a/vector/CMakeLists.txt
+++ b/vector/CMakeLists.txt
@@ -805,6 +805,7 @@ build_program_in_subdir(
   grass_dbmidriver
   grass_gis
   grass_vector
+  grass_parson
   GDAL
   LIBM)
 


### PR DESCRIPTION
This PR fixes error related to Parson dependency.

```
   [ 59%] Linking C executable ../../output/lib/grass85/bin/r.univar
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/r.univar.dir/stats.c.o: undefined reference to symbol 'json_object_set_string@@JSONC_0.14'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: /home/mahesh/miniconda3/envs/new_grass/lib/libjson-c.so.5: error adding symbols: DSO missing from command line
   collect2: error: ld returned 1 exit status
   make[2]: *** [raster/r.univar/CMakeFiles/r.univar.dir/build.make:134: output/lib/grass85/bin/r.univar] Error 1
   make[1]: *** [CMakeFiles/Makefile2:12989: raster/r.univar/CMakeFiles/r.univar.dir/all] Error 2
   make: *** [Makefile:134: all] Error 2
```
(or)
```
   [ 85%] Linking C executable ../output/lib/grass85/bin/v.univar
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/v.univar.dir/v.univar/main.c.o: in function `summary':
   main.c:(.text+0x1e12): undefined reference to `json_value_init_object'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1e4f): undefined reference to `json_object'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1e81): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1ebe): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1eee): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1f1c): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x1f4c): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/v.univar.dir/v.univar/main.c.o:main.c:(.text+0x1f6e): more undefined references to `json_object_set_number' follow
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: CMakeFiles/v.univar.dir/v.univar/main.c.o: in function `summary':
   main.c:(.text+0x2b85): undefined reference to `json_value_init_array'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2b95): undefined reference to `json_array'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2b9e): undefined reference to `json_value_init_object'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2bae): undefined reference to `json_object'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2be0): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2bff): undefined reference to `json_object_set_number'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2c12): undefined reference to `json_array_append_value'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2c2c): undefined reference to `json_object_set_value'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2f24): undefined reference to `json_serialize_to_string_pretty'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2f6d): undefined reference to `json_free_serialized_string'
   /home/mahesh/miniconda3/envs/new_grass/bin/../lib/gcc/x86_64-conda-linux-gnu/14.1.0/../../../../x86_64-conda-linux-gnu/bin/ld: main.c:(.text+0x2f79): undefined reference to `json_value_free'
   collect2: error: ld returned 1 exit status
   make[2]: *** [vector/CMakeFiles/v.univar.dir/build.make:104: output/lib/grass85/bin/v.univar] Error 1
   make[1]: *** [CMakeFiles/Makefile2:20701: vector/CMakeFiles/v.univar.dir/all] Error 2
   ```